### PR TITLE
added Dockerfile and updated main README.md

### DIFF
--- a/.github/workflows/linux-cpp.yml
+++ b/.github/workflows/linux-cpp.yml
@@ -29,3 +29,20 @@ jobs:
             ./*
             test/* 
         retention-days: 14
+
+  build-docker:
+      
+      runs-on: ubuntu-latest
+  
+      steps:
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build to test
+        uses: docker/build-push-action@v5
+        with:
+          push: false
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,39 @@
+FROM ubuntu:jammy
+
+LABEL base.image="ubuntu:jammy"
+LABEL software="stxtyper"
+LABEL description="Scan contig files against PubMLST typing schemes"
+LABEL website="https://github.com/evolarjun/stxtyper"
+LABEL license="https://github.com/evolarjun/stxtyper/blob/main/LICENSE"
+LABEL maintainer="Curtis Kapsak"
+LABEL maintainer.email="kapsakcj@gmail.com"
+
+# install dependencies via apt; cleanup apt garbage
+# blast from ubuntu:jammy is v2.12.0 (as of 2024-03-26)
+# procps is for ps command (required for nextflow)
+RUN apt-get update && apt-get install -y --no-install-recommends \
+ wget \
+ ca-certificates \
+ make \ 
+ g++ \
+ ncbi-blast+ \
+ procps && \
+ apt-get autoclean && rm -rf /var/lib/apt/lists/*
+
+# bring in stxtyper code
+COPY . /stxtyper
+
+# compile 
+# run test script
+# TODO in future: move executables to /usr/local/bin and delete source code (for smaller image) 
+RUN cd /stxtyper && \
+    make && \
+    bash test_stxtyper.sh && \
+    tblastn -help && \
+    ./stxtyper --help
+
+# set PATH to include where stxtyper & fasta_check executables exist
+ENV PATH="${PATH}:/stxtyper" 
+
+# set final working directory as /data for passing data in/out of container
+WORKDIR /data

--- a/README.md
+++ b/README.md
@@ -39,6 +39,24 @@ If you install BLAST via conda in this way you will need to run `conda activate 
     make
     make test
 
+## Docker
+
+Pre-built docker images are available on [Dockerhub](https://hub.docker.com/r/kapsakcj/stxtyper), though they may not be as up-to-date as the source code. To pull the image from Dockerhub, run:
+
+```bash
+# Pull the latest image
+docker pull kapsakcj/stxtyper:latest
+
+# Optionally, pull from a specific commit hash
+docker pull kapsakcj/stxtyper:<commit_hash>
+```
+
+A Dockerfile is included in the repository. To build the Docker image locally, run this command when in the root directory of the repository:
+
+```bash
+docker build -t stxtyper .
+```
+
 # Usage
 
     stxtyper -n <assembled_nucleotide.fa> [<options>]


### PR DESCRIPTION
Added a dockerfile to the repo and added with instructions for pulling the pre-built image from dockerhub.

I manually built and pushed the docker image to my personal dockerhub repo here: https://hub.docker.com/r/kapsakcj/stxtyper using these commands:

```
docker build --no-cache -t kapsakcj/stxtyper:latest .
docker tag kapsakcj/stxtyper:latest kapsakcj/stxtyper:8328c4d
docker push kapsakcj/stxtyper:latest
docker push kapsakcj/stxtyper:8328c4d
```

FYI - The 2 docker image tags `latest` and `8328c4d` are the same docker image (for now!).

The `latest` tag will change without warning and the commit-hash tag will stay static. I'll try to update the docker image as code changes are made in the future

We should consider switching to using NCBI's dockerhub account, especially if we are thinking about automating the docker image building and deployment steps

One downside of dockerhub is that there are pull limits, which limit the # of times a user can download the image. This can be a problem when you have lots of users pulling the docker image quickly (for example if someone is analyzing a large batch of E. coli in parallel which can required pulling the image repeatedly - depending on your setup. But hey, it's free to use! 

The StaPH-B dockerhub repo does not have these pull limits due to the "open source designation", but the StaPH-B group (of which I'm a maintainer) generally prefers to wait to add tools to their collection until they have matured & are versioned so that we can pin versions. We would prefer to wait until the tool is tested/validated/ready for production use.